### PR TITLE
Disable custom transitions for browser's built-in navigations

### DIFF
--- a/components/BottomPane.vue
+++ b/components/BottomPane.vue
@@ -3,7 +3,7 @@
     <transitioned-link
       v-for="tab in tabs"
       :key="tab.path"
-      :to="tab.path"
+      :path="tab.path"
       :class="{ active: tab.path === currentTabPath }"
       class="tab"
     >

--- a/components/BottomPane.vue
+++ b/components/BottomPane.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="bottom-pane">
-    <nuxt-link
+    <transitioned-link
       v-for="tab in tabs"
       :key="tab.path"
       :to="tab.path"
@@ -8,14 +8,19 @@
       class="tab"
     >
       <font-awesome-icon size="lg" :icon="tab.icon" />
-    </nuxt-link>
+    </transitioned-link>
   </div>
 </template>
 
 <script>
+import TransitionedLink from '~/components/TransitionedLink'
 import { isPreferencesTabPid, pidFromPath } from '~/lib/utils'
+
 export default {
   name: 'BottomPane',
+  components: {
+    TransitionedLink
+  },
   computed: {
     currentTabPath () {
       return isPreferencesTabPid(pidFromPath(this.$route.path)) ? '/preferences' : '/'

--- a/components/CardList.vue
+++ b/components/CardList.vue
@@ -49,8 +49,8 @@
       </omni-list>
     </template>
 
-    <fade-in-out>
-      <shuffle-button v-if="!leaving && special.random" class="shuffle-button" @click="shuffle" />
+    <fade-in-out :enabled="shuffleButtonTransitionEnabled">
+      <shuffle-button v-if="shuffleButtonVisible" class="shuffle-button" @click="shuffle" />
     </fade-in-out>
 
     <fade-in-out>
@@ -94,6 +94,8 @@ export default {
       debugStats: {},
       debugStatus: 'initial',
       leaving: false,
+      shuffleButtonTransitionEnabled: false,
+      shuffleButtonVisible: false,
       shuffleCount: 0,
       xcards: this.$route.query.rsid
         ? xcardsAndMetaFromRsid(this.$route.query.rsid).xcards
@@ -148,6 +150,12 @@ export default {
         return null
       }
     },
+    shouldEnableTransition () {
+      return !!this.$route.params.transition
+    },
+    shuffleButtonVisibleInRealtime () {
+      return !this.leaving && this.special.random
+    },
     sortedXcards () {
       return sortXcards(this.xcards)
     },
@@ -165,12 +173,22 @@ export default {
     pid () {
       this.onUpdateXcards()
     },
+    shuffleButtonVisibleInRealtime (newValue) {
+      this.shuffleButtonTransitionEnabled = this.shouldEnableTransition
+      this.$nextTick(() => {
+        this.shuffleButtonVisible = newValue
+      })
+    },
     xcards: {
       handler () {
         this.onUpdateXcards()
       },
       deep: true
     }
+  },
+  created () {
+    this.shuffleButtonTransitionEnabled = this.shouldEnableTransition
+    this.shuffleButtonVisible = this.shuffleButtonVisibleInRealtime
   },
   mounted () {
     this.onUpdateXcards()

--- a/components/CardList.vue
+++ b/components/CardList.vue
@@ -200,10 +200,11 @@ export default {
           return
         }
         this.$router.replace({
-          path: this.$route.path,
+          name: this.$route.name,
           query: {
             rsid
-          }
+          },
+          params: this.$route.params
         })
       }
     },

--- a/components/FadeInOut.vue
+++ b/components/FadeInOut.vue
@@ -10,7 +10,7 @@ export default {
   props: {
     enabled: {
       type: Boolean,
-      default: false
+      default: true
     }
   }
 }

--- a/components/FadeInOut.vue
+++ b/components/FadeInOut.vue
@@ -1,12 +1,18 @@
 <template>
-  <transition name="fade" appear>
+  <transition :name="enabled ? 'fade' : 'none'" appear>
     <slot />
   </transition>
 </template>
 
 <script>
 export default {
-  name: 'FadeInOut'
+  name: 'FadeInOut',
+  props: {
+    enabled: {
+      type: Boolean,
+      default: false
+    }
+  }
 }
 </script>
 

--- a/components/LinkListItem.vue
+++ b/components/LinkListItem.vue
@@ -1,6 +1,6 @@
 <template>
   <omni-list-item
-    :to="path"
+    :path="path"
     component="transitioned-link"
     clickable
     class="link-list-item link"

--- a/components/LinkListItem.vue
+++ b/components/LinkListItem.vue
@@ -1,7 +1,7 @@
 <template>
   <omni-list-item
     :to="path"
-    component="nuxt-link"
+    component="transitioned-link"
     clickable
     class="link-list-item link"
   >
@@ -11,6 +11,9 @@
 
 <script>
 import OmniListItem from '~/components/OmniListItem'
+
+// TransitionedLink is preloaded.
+// Importing and adding it to 'components' don't work for some reason.
 
 export default {
   name: 'LinkListItem',

--- a/components/OmniListItem.vue
+++ b/components/OmniListItem.vue
@@ -1,7 +1,7 @@
 <template>
   <component
     :is="component"
-    :to="to"
+    :path="path"
     :class="{ clickable }"
     class="list-item"
     @click="$emit('click')"
@@ -22,7 +22,7 @@ export default {
       type: String,
       default: 'div'
     },
-    to: {
+    path: {
       type: String,
       default: null
     }

--- a/components/TopPane.vue
+++ b/components/TopPane.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="top-pane">
     <fade-in-out>
-      <transitioned-link v-if="toBack" :to="toBack" class="back-to-parent-button">
+      <transitioned-link v-if="toBack" :path="toBack" class="back-to-parent-button">
         <div class="back-to-parent-button-inner">
           <font-awesome-icon icon="chevron-left" size="lg" />
         </div>

--- a/components/TopPane.vue
+++ b/components/TopPane.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="top-pane">
-    <fade-in-out>
+    <fade-in-out :enabled="shouldEnableIconTransition">
       <transitioned-link v-if="toBack" :path="toBack" class="back-to-parent-button">
         <div class="back-to-parent-button-inner">
           <font-awesome-icon icon="chevron-left" size="lg" />
@@ -14,7 +14,7 @@
         </div>
       </transition>
     </div>
-    <fade-in-out>
+    <fade-in-out :enabled="shouldEnableIconTransition">
       <a
         v-if="shareablePage"
         :href="shareUrl"
@@ -86,6 +86,9 @@ export default {
         encodeURIComponent(`${baseMessage} #hatokura ${permalink}`)
       ]
       return ss.join('')
+    },
+    shouldEnableIconTransition () {
+      return this.$route.params.transition
     },
     title () {
       return titleFromPid(this.pid)

--- a/components/TopPane.vue
+++ b/components/TopPane.vue
@@ -14,7 +14,7 @@
         </div>
       </transition>
     </div>
-    <fade-in-out :enabled="shouldEnableIconTransition">
+    <fade-in-out :enabled="shareablePageTransitionEnabled">
       <a
         v-if="shareablePage"
         :href="shareUrl"
@@ -44,6 +44,8 @@ export default {
   },
   data () {
     return {
+      shareablePage: undefined,
+      shareablePageTransitionEnabled: false,
       titleTransitionBase: 'shift-forward',
       toBack: undefined,
       toBackTransitionEnabled: false
@@ -56,7 +58,7 @@ export default {
     pid () {
       return pidFromPath(this.$route.path)
     },
-    shareablePage () {
+    shareablePageInRealtime () {
       return isCardListPid(this.pid)
     },
     shareableSupply () {
@@ -109,6 +111,12 @@ export default {
         ? 'shift-forward'
         : 'shift-backward'
     },
+    shareablePageInRealtime (newValue) {
+      this.shareablePageTransitionEnabled = this.shouldEnableIconTransition
+      this.$nextTick(() => {
+        this.shareablePage = newValue
+      })
+    },
     toBackInRealtime (newValue) {
       this.toBackTransitionEnabled = this.shouldEnableIconTransition
       this.$nextTick(() => {
@@ -121,6 +129,7 @@ export default {
     // - Their values are necessary for the first rendering.
     // - beforeMount() is not called during server-side rendering.
     // Therefore the following "initial values" must be set in created().
+    this.shareablePage = this.shareablePageInRealtime
     this.toBack = this.toBackInRealtime
   },
   methods: {

--- a/components/TopPane.vue
+++ b/components/TopPane.vue
@@ -44,7 +44,7 @@ export default {
   },
   data () {
     return {
-      titleTransition: 'shift-forward'
+      titleTransitionBase: 'shift-forward'
     }
   },
   computed: {
@@ -90,13 +90,17 @@ export default {
     title () {
       return titleFromPid(this.pid)
     },
+    titleTransition () {
+      const byTap = this.$route.params.transition
+      return byTap ? this.titleTransitionBase : 'none'
+    },
     toBack () {
       return this.$store.getters['history/backPath'](this.pid)
     }
   },
   watch: {
     pid (newPid, oldPid) {
-      this.titleTransition = isForwardTransitionByPids(newPid, oldPid)
+      this.titleTransitionBase = isForwardTransitionByPids(newPid, oldPid)
         ? 'shift-forward'
         : 'shift-backward'
     }

--- a/components/TopPane.vue
+++ b/components/TopPane.vue
@@ -93,7 +93,7 @@ export default {
       ]
       return ss.join('')
     },
-    shouldEnableIconTransition () {
+    shouldEnableTransition () {
       return this.$route.params.transition
     },
     titleInRealtime () {
@@ -119,19 +119,19 @@ export default {
         : 'shift-backward'
     },
     shareablePageInRealtime (newValue) {
-      this.shareablePageTransitionEnabled = this.shouldEnableIconTransition
+      this.shareablePageTransitionEnabled = this.shouldEnableTransition
       this.$nextTick(() => {
         this.shareablePage = newValue
       })
     },
     titleInRealtime (newValue) {
-      this.titleTransitionEnabled = this.shouldEnableIconTransition
+      this.titleTransitionEnabled = this.shouldEnableTransition
       this.$nextTick(() => {
         this.title = newValue
       })
     },
     toBackInRealtime (newValue) {
-      this.toBackTransitionEnabled = this.shouldEnableIconTransition
+      this.toBackTransitionEnabled = this.shouldEnableTransition
       this.$nextTick(() => {
         this.toBack = newValue
       })

--- a/components/TopPane.vue
+++ b/components/TopPane.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="top-pane">
     <fade-in-out>
-      <nuxt-link v-if="toBack" :to="toBack" class="back-to-parent-button">
+      <transitioned-link v-if="toBack" :to="toBack" class="back-to-parent-button">
         <div class="back-to-parent-button-inner">
           <font-awesome-icon icon="chevron-left" size="lg" />
         </div>
-      </nuxt-link>
+      </transitioned-link>
     </fade-in-out>
     <div class="title">
       <transition :name="transition">
@@ -33,12 +33,14 @@
 
 <script>
 import FadeInOut from '~/components/FadeInOut'
+import TransitionedLink from '~/components/TransitionedLink'
 import { isCardListPid, isForwardTransitionByPids, permalinkFromPid, pidFromPath, sidFromPid, sortXcards, titleFromPid, xcardsFromPid } from '~/lib/utils'
 
 export default {
   name: 'TopPane',
   components: {
-    FadeInOut
+    FadeInOut,
+    TransitionedLink
   },
   data () {
     return {

--- a/components/TopPane.vue
+++ b/components/TopPane.vue
@@ -8,7 +8,7 @@
       </transitioned-link>
     </fade-in-out>
     <div class="title">
-      <transition :name="transition">
+      <transition :name="titleTransition">
         <div :key="title" class="text">
           <span>{{ title }}</span>
         </div>
@@ -44,7 +44,7 @@ export default {
   },
   data () {
     return {
-      transition: 'shift-forward'
+      titleTransition: 'shift-forward'
     }
   },
   computed: {
@@ -96,7 +96,7 @@ export default {
   },
   watch: {
     pid (newPid, oldPid) {
-      this.transition = isForwardTransitionByPids(newPid, oldPid)
+      this.titleTransition = isForwardTransitionByPids(newPid, oldPid)
         ? 'shift-forward'
         : 'shift-backward'
     }

--- a/components/TopPane.vue
+++ b/components/TopPane.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="top-pane">
-    <fade-in-out :enabled="shouldEnableIconTransition">
+    <fade-in-out :enabled="toBackTransitionEnabled">
       <transitioned-link v-if="toBack" :path="toBack" class="back-to-parent-button">
         <div class="back-to-parent-button-inner">
           <font-awesome-icon icon="chevron-left" size="lg" />
@@ -44,7 +44,9 @@ export default {
   },
   data () {
     return {
-      titleTransitionBase: 'shift-forward'
+      titleTransitionBase: 'shift-forward',
+      toBack: undefined,
+      toBackTransitionEnabled: false
     }
   },
   computed: {
@@ -97,7 +99,7 @@ export default {
       const byTap = this.$route.params.transition
       return byTap ? this.titleTransitionBase : 'none'
     },
-    toBack () {
+    toBackInRealtime () {
       return this.$store.getters['history/backPath'](this.pid)
     }
   },
@@ -106,7 +108,20 @@ export default {
       this.titleTransitionBase = isForwardTransitionByPids(newPid, oldPid)
         ? 'shift-forward'
         : 'shift-backward'
+    },
+    toBackInRealtime (newValue) {
+      this.toBackTransitionEnabled = this.shouldEnableIconTransition
+      this.$nextTick(() => {
+        this.toBack = newValue
+      })
     }
+  },
+  created () {
+    // - Computed properties are not available in data().
+    // - Their values are necessary for the first rendering.
+    // - beforeMount() is not called during server-side rendering.
+    // Therefore the following "initial values" must be set in created().
+    this.toBack = this.toBackInRealtime
   },
   methods: {
     share (e) {

--- a/components/TopPane.vue
+++ b/components/TopPane.vue
@@ -94,7 +94,7 @@ export default {
       return ss.join('')
     },
     shouldEnableTransition () {
-      return this.$route.params.transition
+      return !!this.$route.params.transition
     },
     titleInRealtime () {
       return titleFromPid(this.pid)

--- a/components/TransitionedLink.vue
+++ b/components/TransitionedLink.vue
@@ -5,16 +5,33 @@
 </template>
 
 <script>
+import { pidFromPath } from '~/lib/utils'
+
+const staticRouteNameMap = new Map([
+  ['/', 'index'],
+  ['/about', 'about'],
+  ['/preferences', 'preferences'],
+  ['/preferences/banned-cards', 'preferences-banned-cards']
+])
+
 export default {
   props: {
     to: {
-      type: [String, Object],
+      type: String,
       required: true
     }
   },
   computed: {
     normalizedTo () {
-      return this.$props.to
+      const name = staticRouteNameMap.get(this.to) || 'pid'
+      const pid = name !== 'pid' ? undefined : pidFromPath(this.to)
+      return {
+        name,
+        params: {
+          pid,
+          transition: true
+        }
+      }
     }
   }
 }

--- a/components/TransitionedLink.vue
+++ b/components/TransitionedLink.vue
@@ -5,14 +5,8 @@
 </template>
 
 <script>
+import { nameFromPath } from '~/lib/router'
 import { pidFromPath } from '~/lib/utils'
-
-const staticRouteNameMap = new Map([
-  ['/', 'index'],
-  ['/about', 'about'],
-  ['/preferences', 'preferences'],
-  ['/preferences/banned-cards', 'preferences-banned-cards']
-])
 
 export default {
   props: {
@@ -23,7 +17,7 @@ export default {
   },
   computed: {
     normalizedTo () {
-      const name = staticRouteNameMap.get(this.path) || 'pid'
+      const name = nameFromPath(this.path)
       const pid = name !== 'pid' ? undefined : pidFromPath(this.path)
       return {
         name,

--- a/components/TransitionedLink.vue
+++ b/components/TransitionedLink.vue
@@ -5,8 +5,7 @@
 </template>
 
 <script>
-import { nameFromPath } from '~/lib/router'
-import { pidFromPath } from '~/lib/utils'
+import { toFromPath } from '~/lib/router'
 
 export default {
   props: {
@@ -17,15 +16,7 @@ export default {
   },
   computed: {
     normalizedTo () {
-      const name = nameFromPath(this.path)
-      const pid = name !== 'pid' ? undefined : pidFromPath(this.path)
-      return {
-        name,
-        params: {
-          pid,
-          transition: true
-        }
-      }
+      return toFromPath(this.path, { transition: true })
     }
   }
 }

--- a/components/TransitionedLink.vue
+++ b/components/TransitionedLink.vue
@@ -1,0 +1,24 @@
+<template>
+  <nuxt-link :to="normalizedTo">
+    <slot />
+  </nuxt-link>
+</template>
+
+<script>
+export default {
+  props: {
+    to: {
+      type: [String, Object],
+      required: true
+    }
+  },
+  computed: {
+    normalizedTo () {
+      return this.$props.to
+    }
+  }
+}
+</script>
+
+<style scoped>
+</style>

--- a/components/TransitionedLink.vue
+++ b/components/TransitionedLink.vue
@@ -16,15 +16,15 @@ const staticRouteNameMap = new Map([
 
 export default {
   props: {
-    to: {
+    path: {
       type: String,
       required: true
     }
   },
   computed: {
     normalizedTo () {
-      const name = staticRouteNameMap.get(this.to) || 'pid'
-      const pid = name !== 'pid' ? undefined : pidFromPath(this.to)
+      const name = staticRouteNameMap.get(this.path) || 'pid'
+      const pid = name !== 'pid' ? undefined : pidFromPath(this.path)
       return {
         name,
         params: {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -15,6 +15,7 @@
 <script>
 import BottomPane from '~/components/BottomPane'
 import TopPane from '~/components/TopPane'
+import { toFromPath } from '~/lib/router'
 import { pidFromPath } from '~/lib/utils'
 
 export default {
@@ -27,6 +28,13 @@ export default {
       return pidFromPath(this.$route.path)
     },
     toBack () {
+      if (this.toBackPath === undefined) {
+        return undefined
+      }
+
+      return toFromPath(this.toBackPath, { transition: true })
+    },
+    toBackPath () {
       const backPath = this.$store.getters['history/backPath'](this.pid)
       if (backPath) {
         return backPath

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,9 +1,23 @@
+import { pidFromPath } from '~/lib/utils'
+
 let nameFromPathMap
 
 export function setUp (routes) {
   nameFromPathMap = new Map(routes.map(r => [r.path, r.name]))
 }
 
-export function nameFromPath (path) {
+function nameFromPath (path) {
   return nameFromPathMap.get(path) || 'pid'
+}
+
+export function toFromPath (path, params = {}) {
+  const name = nameFromPath(path)
+  const pid = name !== 'pid' ? undefined : pidFromPath(path)
+  return {
+    name,
+    params: {
+      ...params,
+      pid
+    }
+  }
 }

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,0 +1,9 @@
+let nameFromPathMap
+
+export function setUp (routes) {
+  nameFromPathMap = new Map(routes.map(r => [r.path, r.name]))
+}
+
+export function nameFromPath (path) {
+  return nameFromPathMap.get(path) || 'pid'
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1791,8 +1791,13 @@ export function excerptFromPid (pid) {
 }
 
 export function transition (to, from) {
+  const byTap = to.params.transition
   return {
-    name: isForwardTransitionByRoutes(to, from) ? 'page-forward' : 'page-backward',
+    name: byTap ? (
+      isForwardTransitionByRoutes(to, from) ? 'page-forward' : 'page-backward'
+    ) : (
+      'none'
+    ),
     mode: ''
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1791,9 +1791,9 @@ export function excerptFromPid (pid) {
 }
 
 export function transition (to, from) {
-  const byTap = to.params.transition
+  const shouldEnableTransition = to.params.transition
   return {
-    name: byTap ? (
+    name: shouldEnableTransition ? (
       isForwardTransitionByRoutes(to, from) ? 'page-forward' : 'page-backward'
     ) : (
       'none'

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -32,6 +32,7 @@ export default {
   ],
   plugins: [
     '~/plugins/fontawesome',
+    '~/plugins/preloaded-components',
     '~/plugins/router',
     '~/plugins/vue2-touch-events',
     { src: '~/plugins/hooks.client', mode: 'client' }

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -11,11 +11,11 @@
       <p>
         <external-link href="http://hatokura.flipflops.jp/rule" label="ルールブック" />
         には初めてプレイする際に最適な
-        <transitioned-link to="supplies:basic">
+        <transitioned-link path="/supplies:basic">
           推奨サプライ
         </transitioned-link>
         が記載されていますが、ある程度ゲームに慣れてくると
-        <transitioned-link to="supplies:random">
+        <transitioned-link path="/supplies:random">
           ランダム選択でサプライを決める
         </transitioned-link>
         ようになります。

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -11,13 +11,13 @@
       <p>
         <external-link href="http://hatokura.flipflops.jp/rule" label="ルールブック" />
         には初めてプレイする際に最適な
-        <nuxt-link to="supplies:basic">
+        <transitioned-link to="supplies:basic">
           推奨サプライ
-        </nuxt-link>
+        </transitioned-link>
         が記載されていますが、ある程度ゲームに慣れてくると
-        <nuxt-link to="supplies:random">
+        <transitioned-link to="supplies:random">
           ランダム選択でサプライを決める
-        </nuxt-link>
+        </transitioned-link>
         ようになります。
         ところがコモンカード10種類をランダムに選択するのは案外大変です。
         このツールが快適なゲームプレイの一助となれば幸いです。
@@ -68,6 +68,7 @@ import LinkButtonListItem from '~/components/LinkButtonListItem'
 import OmniList from '~/components/OmniList'
 import OmniListItem from '~/components/OmniListItem'
 import PageContainer from '~/components/PageContainer'
+import TransitionedLink from '~/components/TransitionedLink'
 import { ogpMetaFromPid, titleTagValueFromPid, transition } from '~/lib/utils'
 
 export default {
@@ -76,7 +77,8 @@ export default {
     LinkButtonListItem,
     OmniList,
     OmniListItem,
-    PageContainer
+    PageContainer,
+    TransitionedLink
   },
   computed: {
     isRunningInStandaloneMode () {

--- a/pages/preferences/index.vue
+++ b/pages/preferences/index.vue
@@ -99,7 +99,7 @@
 
     <preference-switch v-model="avoidRecentlyUsedCards" title="最近使用したカードをなるべく避ける">
       <template v-slot:note>
-        <transitioned-link to="/supplies:log">
+        <transitioned-link path="/supplies:log">
           最近使用したサプライ
         </transitioned-link>に含まれるカードの出現確率を下げます。使用回数が多いほど出現確率は下がります。ただし出現確率が完全に0になることはありません。
       </template>

--- a/pages/preferences/index.vue
+++ b/pages/preferences/index.vue
@@ -99,9 +99,9 @@
 
     <preference-switch v-model="avoidRecentlyUsedCards" title="最近使用したカードをなるべく避ける">
       <template v-slot:note>
-        <nuxt-link to="/supplies:log">
+        <transitioned-link to="/supplies:log">
           最近使用したサプライ
-        </nuxt-link>に含まれるカードの出現確率を下げます。使用回数が多いほど出現確率は下がります。ただし出現確率が完全に0になることはありません。
+        </transitioned-link>に含まれるカードの出現確率を下げます。使用回数が多いほど出現確率は下がります。ただし出現確率が完全に0になることはありません。
       </template>
     </preference-switch>
 
@@ -122,6 +122,7 @@ import OmniListItem from '~/components/OmniListItem'
 import PageContainer from '~/components/PageContainer'
 import PreferenceSwitch from '~/components/PreferenceSwitch'
 import SegmentedButtonGroup from '~/components/SegmentedButtonGroup'
+import TransitionedLink from '~/components/TransitionedLink'
 import { EXPANSIONS, cardFromCid, ogpMetaFromPid, titleTagValueFromPid, transition } from '~/lib/utils'
 
 function mapOptionStore (keys) {
@@ -150,7 +151,8 @@ export default {
     OmniListItem,
     PageContainer,
     PreferenceSwitch,
-    SegmentedButtonGroup
+    SegmentedButtonGroup,
+    TransitionedLink
   },
   computed: {
     bannedCardNames () {

--- a/plugins/preloaded-components.js
+++ b/plugins/preloaded-components.js
@@ -1,0 +1,4 @@
+import Vue from 'vue'
+import TransitionedLink from '~/components/TransitionedLink'
+
+Vue.component('transitioned-link', TransitionedLink)

--- a/plugins/router.js
+++ b/plugins/router.js
@@ -1,4 +1,5 @@
 import EventBus from '~/lib/eventbus'
+import { setUp as setUpLibRouter } from '~/lib/router'
 import { parseSpecialPid, pidFromPath } from '~/lib/utils'
 
 export default ({ app }) => {
@@ -15,4 +16,6 @@ export default ({ app }) => {
   app.router.afterEach((to, from) => {
     app.store.dispatch('history/navigate', to.fullPath)
   })
+
+  setUpLibRouter(app.router.options.routes)
 }


### PR DESCRIPTION
Some browser navigations, especially Safari's swipe-to-back gesture, show its own transition before custom transition.  It's annoying to see both transitions.

It's possible to disable Safari's swipe-to-back gesture by calling `preventDefault` on `touchstart`, but it disables custom swipe-to-back gesture as well.

Therefore the only way to avoid showing both transitions is to disable custom transitions only for browser's built-in navigations.